### PR TITLE
Add lazy registration mode (2.1.0)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,11 @@
 /**
  * @typedef {Object<string, () => Promise<any>>} DynamicImportModules
  * @typedef {Object<string, any>} StaticImportModules
- * @typedef {{ resolverOptions?: import('awilix').BuildResolverOptions, formatName?: (name: string) => string }} LoadOptions
+ * @typedef {{
+ *   resolverOptions?: import('awilix').BuildResolverOptions,
+ *   formatName?: (name: string) => string,
+ *   lazy?: boolean
+ * }} LoadOptions
  */
 /**
  * @description
@@ -9,7 +13,7 @@
  * @param {DynamicImportModules|StaticImportModules} globResult - The result of either doing import.meta.glob('/*.ts') or import.meta.glob('/*.ts', { eager: true })
  * @param {LoadOptions} options
  */
-export function loadModules(container: import('awilix').AwilixContainer, globResult: DynamicImportModules | StaticImportModules, options: LoadOptions): void;
+export function loadModules(container: import('awilix').AwilixContainer, globResult: DynamicImportModules | StaticImportModules, options?: LoadOptions): void;
 export type DynamicImportModules = {
     [x: string]: () => Promise<any>;
 };
@@ -19,4 +23,13 @@ export type StaticImportModules = {
 export type LoadOptions = {
     resolverOptions?: import("awilix").BuildResolverOptions<any>;
     formatName?: (name: string) => string;
+    /**
+     * When `true`, modules' default exports are read at resolve time rather than
+     * at registration time. Use this to avoid Vite dev-server module-loading
+     * races in large applications with hundreds of modules in a single eager
+     * glob, where a namespace can occasionally be observed before its `default`
+     * slot is populated. Lazy mode supports default exports only and ignores
+     * `resolverOptions.register`.
+     */
+    lazy?: boolean;
 };

--- a/index.js
+++ b/index.js
@@ -7,7 +7,11 @@ class AwilixViteError extends Error {
 /**
  * @typedef {Object<string, () => Promise<any>>} DynamicImportModules
  * @typedef {Object<string, any>} StaticImportModules
- * @typedef {{ resolverOptions?: import('awilix').BuildResolverOptions, formatName?: (name: string) => string }} LoadOptions
+ * @typedef {{
+ *   resolverOptions?: import('awilix').BuildResolverOptions,
+ *   formatName?: (name: string) => string,
+ *   lazy?: boolean
+ * }} LoadOptions
  */
 
 /**
@@ -21,6 +25,11 @@ export function loadModules(container, globResult, options) {
         throw new AwilixViteError("Dynamic imports detected in the result of import.meta.glob. Please set the eager option to true in the import.meta.glob call like this \"import.meta.glob('/*.ts', { eager: true })\".")
     }
 
+    if (options?.lazy) {
+        registerLazily(container, globResult, options)
+        return
+    }
+
     for(const [path, loadedModule] of Object.entries(globResult)) {
         const [name, resolvedModule] = getNameAndModule(path, loadedModule)
         const formatedName = options?.formatName ? options.formatName(name) : formatNameToCamelCase(name)
@@ -32,21 +41,60 @@ export function loadModules(container, globResult, options) {
 }
 
 /**
- * @param {string} path 
- * @param {any} loadedModule 
+ * Registers each module's default export lazily — `loadedModule.default` is
+ * read inside the resolver factory, not at registration time. This sidesteps
+ * dev-server module-loading races where Vite's SSR loader can hand back a
+ * namespace whose `default` slot isn't yet populated when a very large eager
+ * glob batch is loaded under concurrency.
+ *
+ * Lazy mode supports default exports only. Modules using a RESOLVER-tagged
+ * named export should use the default (eager) mode.
+ *
+ * `resolverOptions.register` is ignored in lazy mode (the resolver is always
+ * `asFunction`, which dispatches via `new` for classes and a plain call for
+ * factory functions). Other resolver options like `lifetime` are passed through.
+ *
+ * @param {import('awilix').AwilixContainer} container
+ * @param {StaticImportModules} globResult
+ * @param {LoadOptions} options
+ */
+function registerLazily(container, globResult, options) {
+    const resolverOptions = stripRegisterOption(options?.resolverOptions)
+
+    for (const [path, loadedModule] of Object.entries(globResult)) {
+        const baseName = extractBaseName(path)
+        const formatedName = options?.formatName ? options.formatName(baseName) : formatNameToCamelCase(baseName)
+
+        container.register(
+            formatedName,
+            asFunction((cradle) => {
+                const value = loadedModule.default
+                if (!isFunction(value)) {
+                    throw new AwilixViteError(buildLazyResolveError(path, loadedModule))
+                }
+                return isClass(value) ? new value(cradle) : value(cradle)
+            }, resolverOptions)
+        )
+    }
+}
+
+/**
+ * @param {import('awilix').BuildResolverOptions | undefined} resolverOptions
+ */
+function stripRegisterOption(resolverOptions) {
+    if (!resolverOptions) return undefined
+    // The `register` option doesn't apply in lazy mode — drop it so awilix
+    // doesn't try to use it as the resolver builder for asFunction.
+    const { register: _register, ...rest } = resolverOptions
+    return rest
+}
+
+/**
+ * @param {string} path
+ * @param {any} loadedModule
  */
 function getNameAndModule(path, loadedModule) {
-    const name = path
-        // Replace Windows path separators with Posix path
-        .replace(/\\/g, '/')
-        // Split the path...
-        .split('/')
-        // ... and take the last part of the filepath
-        .pop()
-        // Split the result with . 
-        .split('.')
-        // And expect the first result of the split to be the name of the file
-        .shift()
+    const name = extractBaseName(path)
 
     if (loadedModule.default && isFunction(loadedModule.default)) {
         // ES6 default export
@@ -70,6 +118,24 @@ function getNameAndModule(path, loadedModule) {
     }
 
     throw new AwilixViteError(buildLoadFailureMessage(path, loadedModule))
+}
+
+/**
+ * Extracts the file's base name from a glob path: `./dir/foo.svelte.ts` -> `foo`.
+ * @param {string} path
+ */
+function extractBaseName(path) {
+    return path
+        // Replace Windows path separators with Posix path
+        .replace(/\\/g, '/')
+        // Split the path...
+        .split('/')
+        // ... and take the last part of the filepath
+        .pop()
+        // Split the result with .
+        .split('.')
+        // And expect the first result of the split to be the name of the file
+        .shift()
 }
 
 /**
@@ -97,6 +163,27 @@ function buildLoadFailureMessage(path, loadedModule) {
         `If this happens sporadically and the file does have a valid default export, ` +
         `you may be hitting a Vite dev-server module-loading race during cold start ` +
         `with very large eager globs — see the readme "Known issues" section.`
+    )
+}
+
+/**
+ * @param {string} path
+ * @param {any} loadedModule
+ */
+function buildLazyResolveError(path, loadedModule) {
+    const hasDefault = 'default' in loadedModule
+    const defaultValue = loadedModule.default
+    const defaultDescriptor = !hasDefault
+        ? 'is missing'
+        : defaultValue === null
+            ? 'is null'
+            : `is ${typeof defaultValue}`
+
+    return (
+        `Module at "${path}" has no callable default export at resolve time ` +
+        `(default ${defaultDescriptor}, expected a class or function). ` +
+        `Lazy mode supports default exports only — for RESOLVER-tagged named ` +
+        `exports use eager mode (omit \`lazy\`).`
     )
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -192,3 +192,134 @@ test('loadModules tolerates primitive named exports when there is no default', (
         }
     );
 });
+
+// -----------------------------------------------------------------------------
+// Lazy mode
+// -----------------------------------------------------------------------------
+
+test('lazy: registers default class and resolves it as an instance', () => {
+    const container = createMockContainer();
+    class Foo {}
+    const modules = { './dir/foo.js': { default: Foo } };
+
+    loadModules(container, modules, { lazy: true });
+
+    assert(container.hasRegistration('foo'), 'foo should be registered');
+    assert(container.resolve('foo') instanceof Foo, 'resolve should produce an instance of Foo');
+});
+
+test('lazy: defers reading mod.default until resolve time', () => {
+    // The whole reason lazy mode exists. If registration eagerly read
+    // `mod.default`, this test would throw at `loadModules` because `default`
+    // is missing on the module record at that moment. The contract is: only
+    // read at resolve time, so registration succeeds even when the namespace
+    // isn't yet populated. Mutating `mod.default` after registration models
+    // the module finishing its evaluation post-bootstrap.
+    const container = createMockContainer();
+    const mod = {};
+    loadModules(container, { './dir/late.js': mod }, { lazy: true });
+
+    assert(container.hasRegistration('late'), 'late should be registered before default is set');
+
+    class Late {}
+    mod.default = Late;
+
+    assert(container.resolve('late') instanceof Late, 'resolve should pick up the now-populated default');
+});
+
+test('lazy: respects resolverOptions.lifetime (SINGLETON)', () => {
+    // Lazy mode passes through `resolverOptions` (sans `register`) to asFunction,
+    // so callers control lifetime the same way they would for any other resolver.
+    const container = createMockContainer();
+    class Singleton {}
+    loadModules(
+        container,
+        { './dir/singleton.js': { default: Singleton } },
+        { lazy: true, resolverOptions: { lifetime: 'SINGLETON' } }
+    );
+
+    assert.strictEqual(container.resolve('singleton'), container.resolve('singleton'), 'should return the cached instance');
+});
+
+test('lazy: defaults to TRANSIENT lifetime (matches eager mode)', () => {
+    const container = createMockContainer();
+    class Each {}
+    loadModules(container, { './dir/each.js': { default: Each } }, { lazy: true });
+
+    const a = container.resolve('each');
+    const b = container.resolve('each');
+    assert(a instanceof Each && b instanceof Each, 'both resolves should be instances');
+    assert.notStrictEqual(a, b, 'transient lifetime should produce a fresh instance per resolve');
+});
+
+test('lazy: throws a descriptive AwilixViteError when default is still missing at resolve time', () => {
+    const container = createMockContainer();
+    loadModules(container, { './dir/nope.js': {} }, { lazy: true });
+
+    assert.throws(
+        () => container.resolve('nope'),
+        (err) => {
+            // Awilix wraps resolver errors. The original AwilixViteError is the cause.
+            const root = err?.cause ?? err;
+            assert.strictEqual(root.name, 'AwilixViteError');
+            assert.match(root.message, /Module at "\.\/dir\/nope\.js" has no callable default export at resolve time/);
+            assert.match(root.message, /default is missing/);
+            return true;
+        }
+    );
+});
+
+test('lazy: passes a working DI cradle to the constructor', () => {
+    const container = createMockContainer();
+    class Logger {}
+    class WithDeps {
+        constructor({ logger }) {
+            this.logger = logger;
+        }
+    }
+    loadModules(
+        container,
+        {
+            './dir/logger.js': { default: Logger },
+            './dir/withDeps.js': { default: WithDeps }
+        },
+        { lazy: true }
+    );
+
+    const instance = container.resolve('withDeps');
+    assert(instance.logger instanceof Logger, 'cradle should resolve declared dependencies');
+});
+
+test('lazy: supports plain factory function default exports (calls without `new`)', () => {
+    const container = createMockContainer();
+    function makeService(cradle) {
+        return { kind: 'factory', cradle };
+    }
+    loadModules(container, { './dir/factory.js': { default: makeService } }, { lazy: true });
+
+    const instance = container.resolve('factory');
+    assert.strictEqual(instance.kind, 'factory', 'factory function should be invoked, not constructed');
+});
+
+test('lazy: respects formatName', () => {
+    const container = createMockContainer();
+    class Foo {}
+    loadModules(container, { './dir/foo.js': { default: Foo } }, { lazy: true, formatName });
+
+    assert(container.hasRegistration('FOO'), 'foo should be registered as FOO');
+});
+
+test('lazy: ignores resolverOptions.register (mode chooses asFunction)', () => {
+    // `register` doesn't make sense when we don't have the resolved module at
+    // registration time. Lazy mode silently strips it so passing the option
+    // alongside `lazy: true` doesn't crash awilix.
+    const container = createMockContainer();
+    class Foo {}
+    loadModules(
+        container,
+        { './dir/foo.js': { default: Foo } },
+        { lazy: true, resolverOptions: { register: asClass } }
+    );
+
+    assert(container.resolve('foo') instanceof Foo);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awilix-vite",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Use Awilix in Vite projects",
   "repository": "kvist-no/awilix-vite",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -101,35 +101,48 @@ Parameters
 - container (required): The Awilix container where the modules should be registered.
 - globResult (required): The result of `import.meta.glob('./dir/*.js', { eager: true })`.
 - options (optional): An object containing the following properties:
-    - resolverOptions: Optional Awilix resolver options.
-    - formatName: Optional function to format module names.
+    - `resolverOptions`: Optional Awilix resolver options (e.g. `lifetime`).
+    - `formatName`: Optional function to format module names.
+    - `lazy`: When `true`, defer reading each module's default export to resolve
+      time. Use this in large applications to avoid Vite dev-server
+      module-loading races. See [Lazy mode](#lazy-mode) below.
 
-## Known issues
+## Lazy mode
 
-### Sporadic "Failed to register module at ..." on dev startup
-
-In large applications (hundreds of modules in a single eager glob), you may
-occasionally see `AwilixViteError: Failed to register module at "<path>"` on a
-cold dev-server start, where the failing path differs between runs. The file
-itself is fine; it has a valid default export.
+By default, `loadModules` reads `loadedModule.default` for every entry as it
+walks the glob result and registers each one immediately. In small projects
+this is fine, but in large applications with hundreds of modules in a single
+eager glob, you may occasionally see `AwilixViteError: Failed to register
+module at "<path>"` on a cold dev-server start — where the failing path
+differs between runs and the file itself has a valid default export.
 
 This is a Vite dev-server module-loading race: under SSR with a very large
-eager glob, a module's namespace can be observed mid-evaluation, with `default`
-not yet populated. `awilix-vite` reads `default` synchronously, so it fails for
-that one module.
+eager glob, a module's namespace can be observed mid-evaluation, with
+`default` not yet populated. The eager read trips on it.
 
-Workarounds on the consumer side:
-- Register modules **lazily** by writing a small wrapper that uses
-  `asFunction((cradle) => new mod.default(cradle)).singleton()`. The
-  `mod.default` access is then deferred to first resolve, by which time module
-  evaluation has completed.
-- Reduce the eager glob's surface area (split it, or move some files behind a
-  separate non-eager glob).
-- Add Vite `server.warmup` entries pointing at the heaviest modules so they're
-  pre-transformed before the request that triggers the glob.
+Pass `lazy: true` to defer the read to first resolve. By then, module
+evaluation has completed and the namespace is fully populated. The race window
+is gone.
 
-If a failure is reproducible (always the same path), the file genuinely lacks
-a usable default export — the error message lists what was found.
+```javascript
+const modules = import.meta.glob('./services/**/*.ts', { eager: true });
+
+loadModules(container, modules, {
+  lazy: true,
+  resolverOptions: { lifetime: 'SINGLETON' }
+});
+```
+
+Lazy mode supports default exports only. For modules using a `RESOLVER`-tagged
+named export, omit `lazy` and use the default (eager) mode. The
+`resolverOptions.register` option is ignored in lazy mode (the resolver is
+always `asFunction`, which dispatches via `new` for classes and a plain call
+for factory functions).
+
+If `default` is still missing or non-callable at resolve time, the resolver
+throws an `AwilixViteError` describing what was actually present. A failure
+that's reproducible at resolve time (always the same module) means the file
+genuinely lacks a usable default export.
 
 ## Why do i have to use `import.meta.glob`?
 


### PR DESCRIPTION
## Summary

Adds `loadModules(..., { lazy: true })` — modules' default exports are read at resolve time instead of registration time. Fixes the dev-server race where a Vite SSR module loader can hand back a namespace whose `default` slot isn't yet populated when a very large eager glob batch is loaded under concurrency. Bumps version to 2.1.0.

```js
const modules = import.meta.glob('./services/**/*.ts', { eager: true });

loadModules(container, modules, {
  lazy: true,
  resolverOptions: { lifetime: 'SINGLETON' }
});
```

## Design notes

- **Default exports only.** Lazy mode supports `export default class … {}` (and plain factory functions). For RESOLVER-tagged named exports, omit `lazy` — eager mode handles those, and detecting them is what made the original code synchronous in the first place.
- **`resolverOptions.register` is ignored** in lazy mode. There's no resolved module at registration time, so a custom register function has nothing to receive. Lazy mode always uses `asFunction` and dispatches via `new` for classes / plain call for factory functions.
- **Other resolver options pass through.** `lifetime`, etc., are forwarded to `asFunction` so callers can opt into singletons the same way they would for any other resolver.
- **Errors at resolve time** are still `AwilixViteError`, with the same diagnostic shape as the eager-mode failure (default present? what type? is it null?). A reproducible resolve-time error means the file genuinely lacks a usable default export.

## Test plan

- [x] `pnpm test` — 19/19 pass (10 pre-existing + 9 new lazy-mode cases)
- [x] Lazy: registers default class and resolves an instance
- [x] Lazy: defers reading `mod.default` until resolve time (registration succeeds against a module record whose `default` is set *after* registration)
- [x] Lazy: respects `resolverOptions.lifetime: 'SINGLETON'`
- [x] Lazy: defaults to TRANSIENT (matches eager-mode default)
- [x] Lazy: descriptive `AwilixViteError` when default still missing at resolve time
- [x] Lazy: cradle resolves declared dependencies
- [x] Lazy: factory function default exports are invoked, not constructed
- [x] Lazy: respects `formatName`
- [x] Lazy: tolerates `resolverOptions.register` being passed (silently strips it)